### PR TITLE
Improve deployment security

### DIFF
--- a/app.yml
+++ b/app.yml
@@ -1,5 +1,5 @@
 name: ssb-room
-image: debian-9-x64
+image: debian-10-x64
 min_size: 1gb
 config:
   #cloud-config

--- a/install.sh
+++ b/install.sh
@@ -2,18 +2,13 @@
 
 cd ~
 
-#
-# install docker
-#
 sudo apt update
-sudo apt install -y curl dnsutils apt-transport-https ca-certificates software-properties-common
-wget https://download.docker.com/linux/debian/gpg -O docker-gpg
-sudo apt-key add docker-gpg
-echo "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | sudo tee -a /etc/apt/sources.list.d/docker.list
-sudo apt update
-sudo apt install -y docker-ce
-sudo systemctl start docker
-sudo systemctl enable docker
+sudo apt install -y docker.io curl dnsutils apt-transport-https ca-certificates software-properties-common unattended-upgrades nginx certbot python3-certbot-nginx
+
+systemctl enable --now docker
+
+echo 'Unattended-Upgrade::Automatic-Reboot "true";' >> /etc/apt/apt.conf.d/50unattended-upgrades
+systemctl restart unattended-upgrades
 
 #
 # install ssb-room image
@@ -26,18 +21,14 @@ docker pull staltz/ssb-room
 mkdir ~/ssb-room-data
 chown -R 1000:1000 ~/ssb-room-data
 
-#
-# Redirect internal 8007 to external 80
-#
-sudo iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 80 -j REDIRECT --to-port 8007
-
 # create ./create-room script
 cat > ./create-room <<EOF
 #!/bin/bash
 memory_limit=$(($(free -b --si | awk '/Mem\:/ { print $2 }') - 200*(10**6)))
 docker run -d --name room \
    -v ~/ssb-room-data/:/home/node/.ssb/ \
-   --network host \
+   -p 127.0.0.1:8007:8007 \
+   -p 8008:8008 \
    --restart unless-stopped \
    --memory "\$memory_limit" \
    staltz/ssb-room
@@ -68,3 +59,85 @@ docker run -d --name healer \
 # ensure containers are always running
 printf '#!/bin/sh\n\ndocker start room\n' | tee /etc/cron.hourly/room && chmod +x /etc/cron.hourly/room
 printf '#!/bin/sh\n\ndocker start healer\n' | tee /etc/cron.hourly/healer && chmod +x /etc/cron.hourly/healer
+
+# auto-update docker images for security
+docker run -d \
+    --name watchtower \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    --restart unless-stopped \
+    containrrr/watchtower
+
+# WARNING: This method of converting an IP address to a domain name
+#          allows the *wildcard DNS provider* to impersonate your service
+#          even if HTTPS is used.
+
+WILDCARD_DNSv4_SUFFIX="nip.io" # xip.io & sslip.io also exist
+WILDCARD_DNSv6_SUFFIX="sslip.io" # only sslip.io has IPv6 support
+PREFIX="ssb-room"
+DOMAIN_V4=$(curl https://ipv4.wtfismyip.com/text 2>/dev/null | tr . - | sed s/\^/${PREFIX}./ | sed s/\$/.${WILDCARD_DNSv4_SUFFIX}/)
+DOMAIN_V6=$(curl https://ipv6.wtfismyip.com/text 2>/dev/null | tr : - | sed s/\^/${PREFIX}./ | sed s/\$/.${WILDCARD_DNSv6_SUFFIX}/)
+
+cat > /etc/nginx/sites-enabled/default <<EOF
+geo \$ipv4 {
+    0.0.0.0/0 ipv4;
+}
+
+geo \$ipv6 {
+   ::0/0 ipv6;
+}
+
+server {
+	listen 80 default_server;
+	listen [::]:80 default_server;
+
+	server_name _;
+
+	location / {
+EOF
+
+if [ ! -z "${DOMAIN_V4}" ]; then
+  cat >> /etc/nginx/sites-enabled/default <<EOF
+      if (\$ipv4) {
+        return 301 https://${DOMAIN_V4};
+      }
+EOF
+fi
+
+if [ ! -z "${DOMAIN_V6}" ]; then
+  cat >> /etc/nginx/sites-enabled/default <<EOF
+      if (\$ipv6) {
+        return 301 https://${DOMAIN_V6};
+      }
+EOF
+fi
+
+cat >> /etc/nginx/sites-enabled/default <<EOF
+    return 404;
+	}
+}
+
+server {
+	listen 80;
+	listen [::]:80;
+
+	server_name ${DOMAIN_V4} ${DOMAIN_V6};
+
+	location / {
+		proxy_pass http://localhost:8007;
+	}
+}
+EOF
+
+systemctl restart nginx
+
+# Random email, change if necessary. Or ask the user to input one?
+EMAIL="$(head /dev/urandom | tr -dc a-z0-9 | head -c 16)@$(head /dev/urandom | tr -dc a-z0-9 | head -c 16).com"
+
+
+if [ ! -z "${DOMAIN_V4}" ]; then
+  certbot --nginx -n -d "${DOMAIN_V4}" --agree-tos --email "${EMAIL}" --redirect
+fi
+
+if [ ! -z "${DOMAIN_V6}" ]; then
+  certbot --nginx -n -d "${DOMAIN_V6}" --agree-tos --email "${EMAIL}" --redirect
+fi


### PR DESCRIPTION
- Install unattended-upgrades (with automatic reboots)
- Setup watchtower for automated docker image updates
- Setup nginx with cerbot for automatic TLS with nip.io-like domain
  and support for IPv4 and IPv6
- Upgrade from Debian Stretch to Buster

Public HTTPS URLs look like:
- IPv4: `https://ssb-room.1-2-3-4.nip.io`
        (replace each . with -)
- IPv6: `https://ssb-room.fe80--3c60-5c2a-287d-5bf5.sslip.io`
        (replace each : with -)