### PR TITLE
Allow tini's arch to be overridden as a docker build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM node:10.16
 MAINTAINER Andre Staltz <contact@staltz.com>
 
 USER root
-ADD https://github.com/krallin/tini/releases/download/v0.18.0/tini /tini
+ARG TINI_SUFFIX
+ADD https://github.com/krallin/tini/releases/download/v0.18.0/tini${TINI_SUFFIX} /tini
 RUN chmod +x /tini
 RUN mkdir /home/node/.npm-global ; \
     chown -R node:node /home/node/


### PR DESCRIPTION
The default tini release is x86_64 only. This PR adds a build argument to the Dockerfile so other arch's can be supported when building the container from source.