### PR TITLE
add Host request header to fix qrcode host

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -124,6 +124,7 @@ server {
 
 	location / {
 		proxy_pass http://localhost:8007;
+		proxy_set_header Host $host;
 	}
 }
 EOF


### PR DESCRIPTION
I created a new room on DigitalOcean and set a custom domain. I faced the problem that the invite code was right in the code text but `net:localhost:8008~[etc]` in the qrcode.

Because the Host request header wasn't being set as the remote one when redirecting, the qrcode was being kept with the server host, aka localhost.