### PR TITLE
Fix onStart callback is missing for server()

### DIFF
--- a/tunnel/client.js
+++ b/tunnel/client.js
@@ -114,7 +114,7 @@ function init(ssb) {
           return msConfig.scope;
         },
 
-        server(onConnect) {
+        server(onConnect, startedCB) {
           // Once a room disconnects, teardown
           pull(
             ssb.conn.hub().listen(),
@@ -148,6 +148,8 @@ function init(ssb) {
               });
             }),
           );
+
+          startedCB();
 
           // close server
           return () => {


### PR DESCRIPTION
Add startedCB callback to server() so that ssb-server's "multiserver:listening" event can be correctly emitted. (To fix #15)