### PR TITLE
Add WebSockets support by default, with optional configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ENV DEBUG="*"
 USER node
 RUN npm install -g ssb-room@1.3.0
 
+EXPOSE 8009
 EXPOSE 8008
 EXPOSE 8007
 

--- a/config.js
+++ b/config.js
@@ -15,6 +15,10 @@ const config = Config('ssb', {
   connections: {
     incoming: {
       net: [{scope: 'public', transform: 'shs', port: 8008, host: '0.0.0.0'}],
+      // Enable this to add WebSockets support over HTTP.
+      // ws: [{scope: 'public', transform: 'shs', port: 8009, host: '0.0.0.0', http: true}],
+      // Enable this (and customize) to add WebSockets support over HTTPS.
+      // ws: [{scope: 'public', transform: 'shs', port: 8009, host: '0.0.0.0', external: ["example.com"], key: "/etc/letsencrypt/live/example.com/privkey.pem", cert: "/etc/letsencrypt/live/example.com/cert.pem" }],
     },
     outgoing: {
       net: [{transform: 'shs'}],

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const SecretStack = require('secret-stack');
 SecretStack({appKey: require('ssb-caps').shs})
   .use(require('ssb-master'))
   .use(require('ssb-logging'))
+  .use(require('ssb-ws'))
   .use(require('ssb-conn'))
   .use(require('./invite'))
   .use(require('./tunnel/server'))

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "ssb-conn": ">=0.11.0",
     "ssb-logging": "~1.0.0",
     "ssb-master": "~1.0.3",
-    "ssb-ref": "~2.13.9"
+    "ssb-ref": "~2.13.9",
+    "ssb-ws": "^6.2.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds support for WebSockets to the default installation, with configuration left disabled by default.  This way WebSockets support can be enabled just using configuration instead of by needing to modify the Docker image or npm package.

Fixes #26.